### PR TITLE
fix IE < 9 https issue

### DIFF
--- a/pages/event/file.php
+++ b/pages/event/file.php
@@ -20,9 +20,10 @@ if(!empty($guid) && !empty($filename)) {
 			
 			$fileHandler->owner_guid = $event->owner_guid;
 			
+			//fix for IE https issue
+			header('Pragma: public');
 			header('Content-Type: '.$file->mime);
-			header('Content-Disposition: Attachment; filename=' . $file->file);
-			header('Pragma: no-cache');				
+			header('Content-Disposition: Attachment; filename=' . $file->file);				
 			
 			echo $fileHandler->grabFile();
 			exit;


### PR DESCRIPTION
Internet Explorer file downloads over SSL do not work with the cache control headers. 
so Cache-control:no-cache doesn't work for IE6,7,8
