### PR TITLE
Combines separate date and time values and handles times as timestamps by default

### DIFF
--- a/lib/events.php
+++ b/lib/events.php
@@ -29,3 +29,25 @@ function event_manager_update_object_handler($event, $type, $object) {
 		}
 	}
 }
+
+/**
+ * Run upgrades
+ *
+ * TODO Once there are more upgrades, mark successful ones to
+ * database to prevent running them more than once.
+ */
+function event_manager_run_upgrades() {
+	$upgrade_path = elgg_get_plugins_path() . 'event_calendar/lib/upgrades/';
+
+	$handle = opendir($upgrade_path);
+
+	while ($upgrade_file = readdir($handle)) {
+		$file_path = $upgrade_path . $upgrade_file;
+
+		if (is_dir($file_path)) {
+			continue;
+		}
+
+		include $file_path;
+	}
+}

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -5,7 +5,7 @@
 
 /**
  * Returns all relationship options
- * 
+ *
  * @return array
  */
 function event_manager_event_get_relationship_options() {
@@ -22,9 +22,9 @@ function event_manager_event_get_relationship_options() {
 
 /**
  * Search for events
- * 
+ *
  * @param array $options search options
- * 
+ *
  * @return array
  */
 function event_manager_search_events($options = array()) {
@@ -55,7 +55,7 @@ function event_manager_search_events($options = array()) {
 		'limit' => $options['limit'],
 		'joins' => array(),
 		'wheres' => array(),
-		'order_by_metadata' => array("name" => 'start_day', "direction" => 'ASC', "as" => "integer")
+		'order_by_metadata' => array("name" => 'start_time', "direction" => 'ASC', "as" => "integer")
 	);
 
 	if ($options["container_guid"]) {
@@ -68,17 +68,17 @@ function event_manager_search_events($options = array()) {
 		$entities_options['wheres'][] = event_manager_search_get_where_sql('oe', array('title', 'description'), $options);
 	}
 
-	if (!empty($options['start_day'])) {
-		$entities_options['metadata_name_value_pairs'][] = array('name' => 'start_day', 'value' => $options['start_day'], 'operand' => '>=');
+	if (!empty($options['start_time'])) {
+		$entities_options['metadata_name_value_pairs'][] = array('name' => 'start_time', 'value' => $options['start_time'], 'operand' => '>=');
 	}
 
-	if (!empty($options['end_day'])) {
-		$entities_options['metadata_name_value_pairs'][] = array('name' => 'end_ts', 'value' => $options['end_day'], 'operand' => '<=');
+	if (!empty($options['end_time'])) {
+		$entities_options['metadata_name_value_pairs'][] = array('name' => 'end_time', 'value' => $options['end_day'], 'operand' => '<=');
 	}
 
 	if (!$options['past_events']) {
 		// only show from current day or newer
-		$entities_options['metadata_name_value_pairs'][] = array('name' => 'start_day', 'value' => mktime(0, 0, 1), 'operand' => '>=');
+		$entities_options['metadata_name_value_pairs'][] = array('name' => 'start_time', 'value' => mktime(0, 0, 1), 'operand' => '>=');
 	}
 
 	if ($options['meattending'] && !empty($options["user_guid"])) {
@@ -144,10 +144,10 @@ function event_manager_search_events($options = array()) {
 
 /**
  * Export the event attendees. Returns csv body
- * 
+ *
  * @param ElggObject $event the event
  * @param string     $rel   relationship type
- * 
+ *
  * @return string
  */
 function event_manager_export_attendees($event, $rel = EVENT_MANAGER_RELATION_ATTENDING) {
@@ -236,11 +236,11 @@ function event_manager_export_attendees($event, $rel = EVENT_MANAGER_RELATION_AT
 
 /**
  * Sanitizes file name
- * 
+ *
  * @param string $string          file name
  * @param bool   $force_lowercase forces file name to lower case
  * @param bool   $anal            only return alfanumeric characters
- * 
+ *
  * @return string
  */
 function event_manager_sanitize_filename($string, $force_lowercase = true, $anal = false) {
@@ -252,7 +252,7 @@ function event_manager_sanitize_filename($string, $force_lowercase = true, $anal
 	$clean = trim(str_replace($strip, "", strip_tags($string)));
 	$clean = preg_replace('/\s+/', "-", $clean);
 	$clean = ($anal) ? preg_replace("/[^a-zA-Z0-9]/", "", $clean) : $clean ;
-	
+
 	return ($force_lowercase) ?
 		(function_exists('mb_strtolower')) ?
 			mb_strtolower($clean, 'UTF-8') :
@@ -262,11 +262,11 @@ function event_manager_sanitize_filename($string, $force_lowercase = true, $anal
 
 /**
  * Returns the where part for a event search sql query
- * 
+ *
  * @param string $table  table prefix
  * @param array  $fields fields to search
  * @param array  $params parameters to search
- * 
+ *
  * @return string
  */
 function event_manager_search_get_where_sql($table, $fields, $params) {
@@ -287,13 +287,13 @@ function event_manager_search_get_where_sql($table, $fields, $params) {
 		$likes[] = "$field LIKE '%$query%'";
 	}
 	$likes_str = implode(' OR ', $likes);
-	
+
 	return "($likes_str)";
 }
 
 /**
  * Returns event region options
- * 
+ *
  * @return bool|array
  */
 function event_manager_event_region_options() {
@@ -338,10 +338,10 @@ function event_manager_event_type_options() {
 }
 
 /**
- * Pad time 
- * 
+ * Pad time
+ *
  * @param string &$value current value to be padded
- * 
+ *
  * @return void
  */
 function event_manager_time_pad(&$value) {
@@ -350,10 +350,10 @@ function event_manager_time_pad(&$value) {
 
 /**
  * Creates an unsubscribe code
- * 
+ *
  * @param EventRegistration $registration registration object
  * @param Event             $event        event
- * 
+ *
  * @return false|string
  */
 function event_manager_create_unsubscribe_code(EventRegistration $registration, Event $event = null) {
@@ -374,10 +374,10 @@ function event_manager_create_unsubscribe_code(EventRegistration $registration, 
 
 /**
  * Returns registration validation url
- * 
+ *
  * @param string $event_guid guid of event
  * @param string $user_guid  guid of user
- * 
+ *
  * @return false|string
  */
 function event_manager_get_registration_validation_url($event_guid, $user_guid) {
@@ -397,10 +397,10 @@ function event_manager_get_registration_validation_url($event_guid, $user_guid) 
 
 /**
  * Returns registration validation code
- * 
+ *
  * @param string $event_guid guid of event
  * @param string $user_guid  guid of user
- * 
+ *
  * @return false|string
  */
 function event_manager_generate_registration_validation_code($event_guid, $user_guid) {
@@ -448,10 +448,10 @@ function event_manager_validate_registration_validation_code($event_guid, $user_
 
 /**
  * Send registration validation email
- * 
+ *
  * @param Event      $event  event
  * @param ElggEntity $entity object or user to send mail to
- * 
+ *
  * @return void
  */
 function event_manager_send_registration_validation_email(Event $event, ElggEntity $entity) {
@@ -486,7 +486,7 @@ function event_manager_send_registration_validation_email(Event $event, ElggEnti
 
 /**
  * Checks if it is allowed to create events in groups
- * 
+ *
  * @return bool
  */
 function event_manager_groups_enabled() {

--- a/lib/upgrades/2014121800-timestamps.php
+++ b/lib/upgrades/2014121800-timestamps.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Updates the event starting and ending times
+ *
+ * - Combines start_time and start_day values
+ * - Renames end_ts to end_time
+ */
+
+$events = new ElggBatch('elgg_get_entities_from_metadata', array(
+	'type' => 'object',
+	'subtype' => Event::SUBTYPE,
+	'limit' => false,
+	'metadata_names' => 'start_day',
+));
+
+foreach ($events as $event) {
+	// Get the starting time as minutes and hours
+	$start_minute = date('i', $event->start_time);
+	$start_hour   = date('H', $event->start_time);
+
+	// Get the starting date as days, months and years
+	$start_day    = date('j', $event->start_day);
+	$start_month  = date('n', $event->start_day);
+	$start_year   = date('Y', $event->start_day);
+
+	// Combine the values into a timestamp
+	$time = mktime($start_hour, $start_minute, 0, $start_month, $start_day, $start_year);
+	$event->start_time = $time;
+	$event->start_day = null;
+
+	// Rename the end_ts metadata to end_time for consistency
+	$event->end_time = $event->end_ts;
+	$event->end_ts = null;
+
+	$event->save();
+}

--- a/procedures/search/events.php
+++ b/procedures/search/events.php
@@ -12,8 +12,8 @@ $owning = get_input('owning');
 $friendsattending = get_input('friendsattending');
 $region = get_input('region');
 $event_type = get_input('event_type');
-$start_day = get_input('start_day');
-$end_day = get_input('end_day');
+$start_time = get_input('start_time');
+$end_time = get_input('end_time');
 $latitude = get_input("latitude");
 $longitude = get_input("longitude");
 $distance = array("latitude" => get_input("distance_latitude"),"longitude" => get_input("distance_longitude"));
@@ -44,19 +44,15 @@ if ($advanced_search) {
 		$options['event_type'] = $event_type;
 	}
 
-	if (!empty($start_day)) {
-		$start_day = explode('-', $start_day);
-		$start_day_ts = mktime(0, 0, 1, $start_day[1], $start_day[2], $start_day[0]);
-		$options['start_day'] = $start_day_ts;
+	if ($start_time) {
+		$options['start_time'] = $start_time;
 	}
 
-	if (!empty($end_day)) {
-		$end_day = explode('-',$end_day);
-		$end_day_ts = mktime(23,59,	59,	$end_day[1], $end_day[2], $end_day[0]);
-		$options['end_day'] = $end_day_ts;
+	if ($end_time) {
+		$options['end_time'] = $end_time;
 	}
 
-	if (empty($end_day) && empty($start_day) && empty($search)) {
+	if (empty($end_time) && empty($start_time) && empty($search)) {
 		$options['past_events'] = false;
 	} else {
 		$options['past_events'] = true;

--- a/start.php
+++ b/start.php
@@ -71,6 +71,8 @@ function event_manager_init() {
 	// events
 	elgg_register_event_handler("update", "object", "event_manager_update_object_handler");
 
+	elgg_register_event_handler("upgrade", "system", "event_manager_run_upgrades");
+
 	// hooks
 	elgg_register_plugin_hook_handler("register", "menu:user_hover", "event_manager_user_hover_menu");
 	elgg_register_plugin_hook_handler("register", "menu:entity", "event_manager_entity_menu", 600);

--- a/views/default/event_manager/event/addthisevent.php
+++ b/views/default/event_manager/event/addthisevent.php
@@ -12,14 +12,14 @@ if (empty($location)) {
 	$location = $event->venue;
 }
 
-$start = date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->start_day) . " " . date('H', $event->start_time) . ":" . date('i', $event->start_time) . ":00";
+$start = date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->start_time) . " " . date('H', $event->start_time) . ":" . date('i', $event->start_time) . ":00";
 
-if ($event->end_ts) {
-	$end = date('Y-m-d H:i:00', $event->end_ts);
+if ($event->end_time) {
+	$end = date('Y-m-d H:i:00', $event->end_time);
 } else {
-	$end_ts = mktime(date('H', $event->start_time), date('i', $event->start_time), 0,date('m', $event->start_day), date('d', $event->start_day), date('Y', $event->start_day));
-	$end_ts = $end_ts + 3600;
-	$end = date('Y-m-d H:i:00', $end_ts);
+	// If no end time defined, default to one hour later
+	$end_time = $event->end_time + 3600;
+	$end = date('Y-m-d H:i:00', $end_time);
 }
 
 $title = $event->title;

--- a/views/default/event_manager/event/pdf.php
+++ b/views/default/event_manager/event/pdf.php
@@ -23,7 +23,7 @@ if ($location = $event->getEventLocation()) {
 	$event_details .= '</td></tr>';
 }
 
-$event_details .= '<tr><td><b>' . elgg_echo('event_manager:edit:form:start_day') . '</b></td><td>: ' . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->start_day) . '</td></tr>';
+$event_details .= '<tr><td><b>' . elgg_echo('event_manager:edit:form:start_day') . '</b></td><td>: ' . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->start_time) . '</td></tr>';
 
 if ($organizer = $event->organizer) {
 	$event_details .= '<tr><td><b>' . elgg_echo('event_manager:edit:form:organizer') . '</b></td><td>: ' . $organizer . '</td></tr>';

--- a/views/default/event_manager/event/view.php
+++ b/views/default/event_manager/event/view.php
@@ -41,10 +41,10 @@ if ($location = $event->getEventLocation()) {
 	$event_details .= '</td></tr>';
 }
 
-$event_details .= '<tr><td><label>' . elgg_echo('event_manager:edit:form:start') . ':</label></td><td>' . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->start_day) . " " . date('H', $event->start_time) . ':' . date('i', $event->start_time) . '</td></tr>';
+$event_details .= '<tr><td><label>' . elgg_echo('event_manager:edit:form:start') . ':</label></td><td>' . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->start_time) . " " . date('H', $event->start_time) . ':' . date('i', $event->start_time) . '</td></tr>';
 
-if ($event->end_ts) {
-	$event_details .= '<tr><td><label>' . elgg_echo('event_manager:edit:form:end') . ':</label></td><td>' . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->end_ts) . " " . date('H', $event->end_ts) . ':' . date('i', $event->end_ts) . '</td></tr>';
+if ($event->end_time) {
+	$event_details .= '<tr><td><label>' . elgg_echo('event_manager:edit:form:end') . ':</label></td><td>' . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->end_time) . " " . date('H', $event->end_time) . ':' . date('i', $event->end_time) . '</td></tr>';
 }
 
 // optional end day

--- a/views/default/event_manager/forms/event/search.php
+++ b/views/default/event_manager/forms/event/search.php
@@ -20,8 +20,8 @@ $form_body .= elgg_view('input/hidden', array('name' => 'advanced_search', 'id' 
 $form_body .= "<table><tr><td class='prl'>";
 
 $form_body .= "<table>";
-$form_body .= "<tr><td class='prm'>" . elgg_echo('event_manager:edit:form:start_day:from') . ':</td><td>' . elgg_view('input/date', array('name' => 'start_day', 'id' => 'start_day')) . '</td></tr>';
-$form_body .= "<tr><td class='prm'>" . elgg_echo('event_manager:edit:form:start_day:to') . ':</td><td>' . elgg_view('input/date', array('name' => 'end_day', 'id' => 'end_day')) . '</td></tr>';
+$form_body .= "<tr><td class='prm'>" . elgg_echo('event_manager:edit:form:start_day:from') . ':</td><td>' . elgg_view('input/date', array('name' => 'start_time', 'id' => 'start_time', 'timestamp' => true)) . '</td></tr>';
+$form_body .= "<tr><td class='prm'>" . elgg_echo('event_manager:edit:form:start_day:to') . ':</td><td>' . elgg_view('input/date', array('name' => 'end_time', 'id' => 'end_time', 'timestamp' => true)) . '</td></tr>';
 $form_body .= "</table>";
 
 $form_body .= "</td>";

--- a/views/default/event_manager/forms/program/day.php
+++ b/views/default/event_manager/forms/program/day.php
@@ -39,7 +39,7 @@ if ($entity && $entity->canEdit()) {
 		$days = $entity->getEventDays();
 		$last_day = end($days);
 		if (!$last_day) {
-			$date = ($entity->start_day + (3600 * 24));
+			$date = ($entity->start_time + (3600 * 24));
 		} else {
 			$date = ($last_day->date + (3600 * 24));
 		}

--- a/views/default/forms/event_manager/event/edit.php
+++ b/views/default/forms/event_manager/event/edit.php
@@ -20,10 +20,8 @@ $fields = array(
 	"twitter_hash" => ELGG_ENTITIES_ANY_VALUE,
 	"organizer" => ELGG_ENTITIES_ANY_VALUE,
 	"organizer_rsvp" => 0,
-	"start_day" => date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, time()),
-	"end_day" => ELGG_ENTITIES_ANY_VALUE,
 	"start_time" => time(),
-	"end_ts" => time() + 3600,
+	"end_time" => time() + 3600,
 	"registration_ended" => ELGG_ENTITIES_ANY_VALUE,
 	"endregistration_day" => ELGG_ENTITIES_ANY_VALUE,
 	"with_program" => ELGG_ENTITIES_ANY_VALUE,
@@ -58,17 +56,6 @@ if ($event) {
 			$fields[$field] = $event->$field;
 		}
 	}
-
-	// convert timestamp to date notation for correct display
-	if (!empty($fields["start_day"])) {
-		$fields["start_day"] = date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $fields["start_day"]);
-	}
-	if (empty($fields["end_ts"])) {
-		$start_date = explode('-', $fields["start_day"]);
-		$fields["end_ts"] = mktime($fields["start_time_hours"], $fields["start_time_minutes"], 1, $start_date[1],$start_date[2],$start_date[0]) + 3600;
-	}
-
-	$fields["end_day"] = date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $fields["end_ts"]);
 }
 
 if (elgg_is_sticky_form('event')) {

--- a/views/default/forms/event_manager/event/tabs/general.php
+++ b/views/default/forms/event_manager/event/tabs/general.php
@@ -12,10 +12,10 @@ $title_input = elgg_view('input/text', array(
 // Starting time
 $start_time_label = elgg_echo('event_manager:edit:form:start');
 $start_day_input = elgg_view('input/date', array(
-	'name' => 'start_day',
-	'id' => 'start_day',
-	'value' => $vars["start_day"],
-	"class" => "event_manager_event_edit_date"
+	'name' => 'start_time',
+	'value' => $vars["start_time"],
+	'class' => 'event_manager_event_edit_date',
+	'timestamp' => true,
 ));
 $start_time_input = elgg_view('input/time', array(
 	'name' => 'start_time',
@@ -25,14 +25,14 @@ $start_time_input = elgg_view('input/time', array(
 // Ending time
 $end_time_label = elgg_echo('event_manager:edit:form:end');
 $end_day_input = elgg_view('input/date', array(
-	'name' => 'end_day',
-	'id' => 'end_day',
-	'value' => $vars["end_day"],
-	"class" => "event_manager_event_edit_date"
+	'name' => 'end_time',
+	'value' => $vars["end_time"],
+	'class' => 'event_manager_event_edit_date',
+	'timestamp' => true,
 ));
 $end_time_input = elgg_view('input/time', array(
 	'name' => 'end_time',
-	'value' => $vars["end_ts"],
+	'value' => $vars["end_time"],
 ));
 
 echo <<<HTML

--- a/views/default/icon/object/event.php
+++ b/views/default/icon/object/event.php
@@ -4,7 +4,7 @@ $entity = elgg_extract("entity", $vars);
 $size = elgg_extract("size", $vars, "medium");
 
 if ($size == "date") {
-	$start_day = $entity->start_day;
+	$start_day = $entity->start_time;
 
 	$icon = "<div class='event_manager_event_list_icon' title='" . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $start_day) . "'>";
 	$icon .= "<div class='event_manager_event_list_icon_month'>" . strtoupper(date("M", $start_day)) . "</div>";

--- a/views/default/object/event.php
+++ b/views/default/object/event.php
@@ -7,7 +7,7 @@ if ($vars["full"]) {
 
 	$output = '<div class="gmaps_infowindow">';
 	$output .= '<div class="gmaps_infowindow_text">';
-	$output .= '<div class="event_manager_event_view_owner"><a href="' . $event->getURL() . '">' . $event->title . '</a> (' . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->start_day) . ')</div>';
+	$output .= '<div class="event_manager_event_view_owner"><a href="' . $event->getURL() . '">' . $event->title . '</a> (' . date(EVENT_MANAGER_FORMAT_DATE_EVENTDAY, $event->start_time) . ')</div>';
 	$output .= $event->getEventLocation(true) . '<br /><br />' . $event->shortdescription . '<br /><br />';
 	$output .= elgg_view("event_manager/event/actions", $vars) . '</div>';
 	if ($event->icontime) {


### PR DESCRIPTION
There's a lot of pitfalls, so it would be best to test this on some actual production data before it gets merged (I don't have any).

 - Combines event starting date and starting time that were previously saved as
   separate timestamps
 - Handles all time values as timestamps by default instead of juggling between
   timestamps and human readable format
 - Renames event ```end_ts``` metadata to ```end_time``` for consistency

- [ ] Test on production data
- [x] Convert  ```views/default/admin/test.php``` page to an upgrade script