### PR TITLE
fix(plugins): fix issue when event access is set as private

### DIFF
--- a/classes/Event.php
+++ b/classes/Event.php
@@ -22,7 +22,8 @@
 			if ($access_id == null) {
 				$access_id = $this->access_id;
 			}
-			
+			// Have to do this for private events
+			$ia = elgg_set_ignore_access(true);
 			if ($eventDays = $this->getEventDays()) {
 				foreach ($eventDays as $day) {
 					$day->access_id = $access_id;
@@ -36,18 +37,25 @@
 					}
 				}
 			}
+			if ($ia) {
+				elgg_set_ignore_access($ia);
+			}
 		}
 		
 		public function setAccessToRegistrationForm($access_id = null) {
 			if ($access_id == null) {
 				$access_id = $this->access_id;
 			}
-			
+			// Have to do this for private events
+			$ia = elgg_set_ignore_access(true);
 			if ($questions = $this->getRegistrationFormQuestions()) {
 				foreach ($questions as $question) {
 					$question->access_id = $access_id;
 					$question->save();
 				}
+			}
+			if ($ia) {
+				elgg_set_ignore_access($ia);
 			}
 		}
 		

--- a/pages/registrationform/edit.php
+++ b/pages/registrationform/edit.php
@@ -17,7 +17,9 @@
 			elgg_push_breadcrumb($title_text);
 			
 			$output  ='<ul id="event_manager_registrationform_fields">';
-			
+			if ($event->access_id == ACCESS_PRIVATE) {
+				$ia = elgg_set_ignore_access(true);
+			}
 			if($registration_form = $event->getRegistrationFormQuestions()) {
 				foreach($registration_form as $question) {
 					$output .= elgg_view('event_manager/registration/question', array('entity' => $question));
@@ -32,7 +34,9 @@
 				'content' => $output,
 				'title' => $title_text,
 			));
-			
+			if ($ia) {
+				elgg_set_ignore_access($ia);
+			}
 			echo elgg_view_page($title_text, $body);			
 		} else {
 			forward($event->getURL());

--- a/procedures/question/edit.php
+++ b/procedures/question/edit.php
@@ -14,6 +14,9 @@
 	
 	if($event_guid && ($event = get_entity($event_guid))) {
 		if(($event->getSubtype() == Event::SUBTYPE) && ($event->canEdit())) {
+			if ($event->access_id == ACCESS_PRIVATE) {
+				$ia=elgg_set_ignore_access(true);
+			}
 			if($question_guid && ($question = get_entity($question_guid))) {
 				if(!($question instanceof EventRegistrationQuestion)) {
 					unset($question);
@@ -46,6 +49,9 @@
 					
 					$result['content'] = elgg_view("event_manager/registration/question", array("entity" => $question));
 				}
+			}
+			if ($event->access_id == ACCESS_PRIVATE) {
+				elgg_set_ignore_access($ia);
 			}
 		}
 	}

--- a/views/default/event_manager/forms/registrationform/question.php
+++ b/views/default/event_manager/forms/registrationform/question.php
@@ -7,11 +7,19 @@
 		// assume new question mode
 		if(!($entity instanceof Event)){
 			unset($entity);
+		} else {
+			if ($entity->canEdit() && $entity->access_id == ACCESS_PRIVATE) {
+				$ia = elgg_set_ignore_access(true);
+			}
 		}
 		
-	} elseif($question_guid && ($entity = get_entity($question_guid))) {
-		// assume question edit mode
-		if(!($entity instanceof EventRegistrationQuestion)){
+	} elseif ($question_guid ) {
+		// Have to do this because of private event
+		$ia = elgg_set_ignore_access(true);
+		$entity = get_entity($question_guid);
+		$associated_event = get_entity($entity->container_guid);
+		// assume question edit mode and check access
+		if(!($entity instanceof EventRegistrationQuestion) || ! $associated_event->canEdit()){
 			unset($entity);
 		}
 	}
@@ -70,4 +78,6 @@
 	} else {
 		echo elgg_echo("InvalidParameterException:GUIDNotFound", array($guid));
 	}
-	
+if ($ia) {
+	elgg_set_ignore_access($ia);
+}


### PR DESCRIPTION

When creating an event with mandatory registration, it would make sense to first make the event
private so that no one can register before the registrations questions have been entered. When
I tried this, I realized I could not add questions because of access controls, hence this fix.